### PR TITLE
Fix build when compiling as C with Visual Studio 2010-2017

### DIFF
--- a/libpopcnt.h
+++ b/libpopcnt.h
@@ -56,6 +56,11 @@
   #define CLANG_PREREQ(x, y) 0
 #endif
 
+#if (_MSC_VER < 1900) && \
+   !defined(__cplusplus)
+#define inline __inline
+#endif
+
 #if (defined(__i386__) || \
      defined(__x86_64__) || \
      defined(_M_IX86) || \
@@ -66,8 +71,9 @@
 #if defined(X86_OR_X64) && \
    (defined(__cplusplus) || \
    (GNUC_PREREQ(4, 2) || \
-    __has_builtin(__sync_val_compare_and_swap)))
-  #define HAVE_CPUID
+    __has_builtin(__sync_val_compare_and_swap)) || \
+    defined(_MSC_VER))
+#define HAVE_CPUID
 #endif
 
 #if GNUC_PREREQ(4, 2) || \
@@ -452,7 +458,11 @@ static inline uint64_t popcnt(const void* data, uint64_t size)
     if (cpuid == -1)
     {
       cpuid = get_cpuid();
+  #if defined(_MSC_VER)
+      _InterlockedCompareExchange(&cpuid_, cpuid, -1);
+  #else
       __sync_val_compare_and_swap(&cpuid_, -1, cpuid);
+  #endif
     }
   #endif
 #endif


### PR DESCRIPTION
Here are some additional changes to support compiling libpopcnt as C in Visual Studio 2010 through 2017:

1. the `inline` keyword is only supported in C++ until Visual Studio 2015
2. define `HAVE_CPUID` when compiling as C with MSVC on x86
3. use equivalent atomic compare and swap function in C with MSVC