### PR TITLE
Add extern 'C' guards to eliminate -Wold-style-cast warnings in C++.

### DIFF
--- a/libpopcnt.h
+++ b/libpopcnt.h
@@ -813,7 +813,7 @@ static inline uint64_t popcnt(const void* data, uint64_t size)
 #endif
 
 #ifdef __cplusplus
-} // extern "C"
+} /* extern "C" */
 #endif
 
 #endif /* LIBPOPCNT_H */

--- a/libpopcnt.h
+++ b/libpopcnt.h
@@ -123,6 +123,10 @@
   #define HAVE_AVX512
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * This uses fewer arithmetic operations than any other known
  * implementation on machines with fast multiplication.
@@ -806,6 +810,10 @@ static inline uint64_t popcnt(const void* data, uint64_t size)
   return cnt;
 }
 
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
 #endif
 
 #endif /* LIBPOPCNT_H */


### PR DESCRIPTION
It's not a substantial change, but wrapping the header in `extern "C"` eliminates warnings regarding casting when used in C++ which aren't appropriate because the code is C and C++ casts obviously wouldn't work.