### PR TITLE
Eliminate temp variables in CSA256

### DIFF
--- a/libpopcnt.h
+++ b/libpopcnt.h
@@ -355,9 +355,14 @@ static inline int get_cpuid()
 #endif
 static inline void CSA256(__m256i* h, __m256i* l, __m256i a, __m256i b, __m256i c)
 {
-  __m256i u = _mm256_xor_si256(a, b);
-  *h = _mm256_or_si256(_mm256_and_si256(a, b), _mm256_and_si256(u, c));
-  *l = _mm256_xor_si256(u, c);
+  b = _mm256_xor_si256(b, a);
+  a = _mm256_xor_si256(a, c);
+  c = _mm256_xor_si256(c, b);
+  b = _mm256_or_si256(b, a);
+  b = _mm256_xor_si256(b, c);
+
+  *l = c;
+  *h = b;
 }
 
 #if !defined(_MSC_VER)


### PR DESCRIPTION
This gets an extra couple GB/s, not quite sure why...
 (GCC 8.3, i7-8700K CPU @ 3.70GHz)

The new expression should produce [equivalent results](http://haroldbot.nl/index.html?q=%28%28a+%26+b%29+%7C+%28%28a+%5E+b%29+%26+c%29%29+%3D%3D+%28%28%28a+%5E+b%29+%7C+%28a+%5E+c%29%29+%5E+%28%28a+%5E+b%29+%5E+c%29%29).
