### PR TITLE
Support AVX512 for MSVC

### DIFF
--- a/libpopcnt.h
+++ b/libpopcnt.h
@@ -115,6 +115,16 @@
 #endif
 
 #if defined(HAVE_CPUID) && \
+    (_MSC_VER >= 1900)
+#define HAVE_AVX2
+#endif
+
+#if defined(HAVE_CPUID) && \
+    (_MSC_VER >= 1910)
+#define HAVE_AVX512
+#endif
+
+#if defined(HAVE_CPUID) && \
     CLANG_PREREQ(3, 8) && \
     __has_attribute(target) && \
    (!defined(_MSC_VER) || defined(__AVX2__)) && \
@@ -480,9 +490,13 @@ static inline __m512i popcnt512(__m512i v)
   __m512i m1 = _mm512_set1_epi8(0x55);
   __m512i m2 = _mm512_set1_epi8(0x33);
   __m512i m4 = _mm512_set1_epi8(0x0F);
-  __m512i t1 = _mm512_sub_epi8(v, (_mm512_srli_epi16(v, 1) & m1));
-  __m512i t2 = _mm512_add_epi8(t1 & m2, (_mm512_srli_epi16(t1, 2) & m2));
-  __m512i t3 = _mm512_add_epi8(t2, _mm512_srli_epi16(t2, 4)) & m4;
+  __m512i vm = _mm512_and_si512(_mm512_srli_epi16(v, 1), m1);
+  __m512i t1 = _mm512_sub_epi8(v, vm);
+  __m512i tm = _mm512_and_si512(t1, m2);
+  __m512i tm2 = _mm512_and_si512(_mm512_srli_epi16(t1, 2), m2);
+  __m512i t2 = _mm512_add_epi8(tm, tm2);
+  __m512i tt = _mm512_add_epi8(t2, _mm512_srli_epi16(t2, 4));
+  __m512i t3 = _mm512_and_si512(tt, m4);
 
   return _mm512_sad_epu8(t3, _mm512_setzero_si512());
 }


### PR DESCRIPTION
As we were discussing here: https://github.com/kimwalisch/libpopcnt/pull/5#issuecomment-641321761

This PR uses intrinsic functions instead of logical operators to fix MSVC compiler errors for AVX512.
It also automatically enables AVX2 and AVX512 if compiling with VS2015 and VS2017 respectively.
I did not remove the existing mechanisms to enable AVX2/AVX512 compilation for MSVC in case people were relying on them.

Unit tests and benchmark look good on VS2019, x86 and x64 w/ AVX2 but I do not have access to a CPU with AVX512 support.